### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,27 +1,42 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = LoggerFactory.getLogger(User.class);
+  private String id;
+  private String username;
+  private String hashedPassword;
 
-  public User(String id, String username, String hashedPassword) {
+  public User(String id, String username, String hashedPassword) { // Alterado por GFT AI Impact Bot
     this.id = id;
     this.username = username;
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() { // Incluido por GFT AI Impact Bot
+    return id;
+  }
+
+  public String getUsername() { // Incluido por GFT AI Impact Bot
+    return username;
+  }
+
+  public String getHashedPassword() { // Incluido por GFT AI Impact Bot
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Alterado por GFT AI Impact Bot
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +46,30 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.error(e.getMessage(), e); // Alterado por GFT AI Impact Bot
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null; // Alterado por GFT AI Impact Bot
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection()) { // Alterado por GFT AI Impact Bot
+      String query = "select * from users where username = ? limit 1"; // Alterado por GFT AI Impact Bot
+      stmt = cxn.prepareStatement(query); // Alterado por GFT AI Impact Bot
+      stmt.setString(1, un); // Incluido por GFT AI Impact Bot
+      LOGGER.info("Opened database successfully"); // Alterado por GFT AI Impact Bot
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id"); // Alterado por GFT AI Impact Bot
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+    } catch (SQLException e) {
+      LOGGER.error(e.getMessage(), e); // Alterado por GFT AI Impact Bot
     }
+    return user; // Alterado por GFT AI Impact Bot
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 6765ea7e9a5599f43f69ce2d4df51dce48f66287
                                                
**Descrição:** Este Pull Request faz várias alterações no arquivo `User.java` para melhorar a qualidade do código e a segurança. Ele substitui a classe `Statement` por `PreparedStatement` para evitar injeção de SQL, adiciona logs para facilitar o rastreamento de erros, e altera a visibilidade dos atributos da classe para privado, fornecendo métodos de acesso a esses atributos (getters).

**Sumario:**

- `src/main/java/com/scalesec/vulnado/User.java` (modificado)
    - Substituição da classe `Statement` por `PreparedStatement` para evitar injeção de SQL.
    - Adição de logs para rastreamento de erros.
    - Alteração na visibilidade dos atributos da classe para privado.
    - Adição de métodos de acesso aos atributos (getters).
    - Remoção de linhas de código desnecessárias e otimização de algumas expressões.

**Recomendações:** Recomenda-se que o revisor verifique se todas as alterações feitas estão em conformidade com as boas práticas de programação. Além disso, é aconselhável realizar testes unitários para garantir que as alterações não introduziram novos bugs no sistema. 

**Explicação de Vulnerabilidades:** O uso de `Statement` pode levar a vulnerabilidades de injeção de SQL, pois permite que consultas SQL sejam construídas dinamicamente e executadas. A injeção de SQL é um tipo comum de ataque em que um atacante pode inserir comandos SQL maliciosos que podem ler, modificar ou até mesmo excluir dados do banco de dados. A troca para `PreparedStatement` resolve essa vulnerabilidade, pois impede a execução de consultas SQL dinâmicas, garantindo que todos os parâmetros sejam tratados como valores literais e não como parte do comando SQL.