### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,27 +1,42 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = LoggerFactory.getLogger(User.class);
+  private String id;
+  private String username;
+  private String hashedPassword;
 
-  public User(String id, String username, String hashedPassword) {
+  public User(String id, String username, String hashedPassword) { // Alterado por GFT AI Impact Bot
     this.id = id;
     this.username = username;
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() { // Incluido por GFT AI Impact Bot
+    return id;
+  }
+
+  public String getUsername() { // Incluido por GFT AI Impact Bot
+    return username;
+  }
+
+  public String getHashedPassword() { // Incluido por GFT AI Impact Bot
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Alterado por GFT AI Impact Bot
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +46,41 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.error(e.getMessage(), e); // Alterado por GFT AI Impact Bot
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null; // Alterado por GFT AI Impact Bot
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+      String query = "select * from users where username = ? limit 1"; // Alterado por GFT AI Impact Bot
+      stmt = cxn.prepareStatement(query); // Alterado por GFT AI Impact Bot
+      stmt.setString(1, un); // Incluido por GFT AI Impact Bot
+      LOGGER.debug("Opened database successfully"); // Alterado por GFT AI Impact Bot
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      LOGGER.debug(query); // Alterado por GFT AI Impact Bot
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id"); // Alterado por GFT AI Impact Bot
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
       cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
+      LOGGER.error(e.getClass().getName()+": "+e.getMessage(), e); // Alterado por GFT AI Impact Bot
     } finally {
-      return user;
+      try {
+        if (stmt != null) {
+          stmt.close(); // Incluido por GFT AI Impact Bot
+        }
+      } catch (SQLException se) {
+        LOGGER.error(se.getMessage(), se); // Alterado por GFT AI Impact Bot
+      }
     }
+    return user; // Alterado por GFT AI Impact Bot
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 8b2e5b313e56a574aff69cafa52bbbb2f412d62e

**Descrição:** O Pull Request aborda diversas melhorias e correções no arquivo User.java. As alterações incluem a troca de `java.sql.Statement` para `java.sql.PreparedStatement` para evitar ataques de injeção de SQL, a substituição de saídas de erro padrão por logs usando `Logger`, e melhorias na estrutura do código para torná-lo mais seguro e legível.

**Sumario:**
- src/main/java/com/scalesec/vulnado/User.java (modificado): 
   - Substituído `java.sql.Statement` por `java.sql.PreparedStatement` para evitar ataques de injeção de SQL.
   - Adicionado `Logger` para substituir saídas de erro padrão.
   - Inclusão de métodos getters para os atributos da classe User.
   - Melhorias na estrutura e legibilidade do código.

**Recomendações:** 
- É importante verificar se todos os cenários possíveis foram cobertos e se a mudança de `java.sql.Statement` para `java.sql.PreparedStatement` foi bem implementada em todos os lugares necessários. 
- Recomenda-se também revisar os novos logs adicionados para garantir que eles estão corretos e úteis.
- A adição dos métodos getters deve ser revisada para garantir que não apresentam possíveis brechas de segurança.

**Explicação de Vulnerabilidades:** A vulnerabilidade que estava presente no código era a possibilidade de ataques de injeção de SQL, que ocorrem quando um invasor consegue inserir instruções SQL indesejadas e maliciosas em uma consulta. Isso foi corrigido substituindo `java.sql.Statement` por `java.sql.PreparedStatement`, que trata todas as entradas como literais e não como parte do SQL, eliminando assim a possibilidade de injeção de SQL.