### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,24 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// Removed unused imports
+// Alterado por GFT AI Impact Bot
+// import org.springframework.boot.*;
+// import org.springframework.http.HttpStatus;
+// import java.io.Serializable;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Make sure allowing safe and unsafe HTTP methods is safe here. Only allowing GET method now. Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Make sure allowing safe and unsafe HTTP methods is safe here. Only allowing GET method now. Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o deafe4180c12ef1e0e5c0a470af179b8e346c5ea

**Descrição:** Este Pull Request faz uma atualização no arquivo src/main/java/com/scalesec/vulnado/LinksController.java. As mudanças incluem a remoção de importações não utilizadas e a alteração das anotações de mapeamento de solicitação para permitir apenas o método GET. 

**Sumário:**
- src/main/java/com/scalesec/vulnado/LinksController.java (modificado)
    - Remoção de importações não utilizadas
    - Alteração das anotações `@RequestMapping` para permitir apenas o método GET

**Recomendações:** 
- Garanta que a alteração para permitir apenas o método GET nas anotações `@RequestMapping` não afeta a funcionalidade da aplicação. 
- Certifique-se de testar todas as funcionalidades que dependem desses endpoints após essa alteração.
- Verifique se não há outras importações não utilizadas no código que poderiam ser removidas para melhorar a limpeza do código.

**Explicação de Vulnerabilidades:** 
- Permitir todos os métodos HTTP pode levar a vulnerabilidades de segurança se não for tratado corretamente. Ao restringir os métodos para GET, podemos prevenir potenciais abusos.
- Importações não utilizadas podem levar a confusão e tornar o código mais difícil de manter e entender. Removê-las melhora a legibilidade do código.