### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,18 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName()); // Alterado por GFT AI Impact Bot
+  private String id; // Alterado por GFT AI Impact Bot
+  private String username; // Alterado por GFT AI Impact Bot
+  private String hashedPassword; // Alterado por GFT AI Impact Bot
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +20,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() { // Incluido por GFT AI Impact Bot
+    return id;
+  }
+
+  public String getUsername() { // Incluido por GFT AI Impact Bot
+    return username;
+  }
+
+  public String getHashedPassword() { // Incluido por GFT AI Impact Bot
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Alterado por GFT AI Impact Bot
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +44,38 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null; // Alterado por GFT AI Impact Bot
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+      String query = "select * from users where username = ? limit 1"; // Alterado por GFT AI Impact Bot
+      stmt = cxn.prepareStatement(query); // Alterado por GFT AI Impact Bot
+      stmt.setString(1, un); // Incluido por GFT AI Impact Bot
+      LOGGER.info("Opened database successfully"); // Alterado por GFT AI Impact Bot
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id"); // Alterado por GFT AI Impact Bot
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
       cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
+      LOGGER.severe(e.getClass().getName()+": "+e.getMessage()); // Alterado por GFT AI Impact Bot
     } finally {
-      return user;
+      try {
+        if (stmt != null) stmt.close(); // Incluido por GFT AI Impact Bot
+      } catch (Exception e) {
+        LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
+      }
     }
+    return user; // Alterado por GFT AI Impact Bot
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for ddf92a9d51e70f44500ba79b2d4b3dedbad848ed

**Description:** This pull request includes several updates to the User.java file. The changes aim to improve code readability, maintainability and enhance security measures.

**Summary:** 

- User.java (modified)
  - Changed the declaration of `id`, `username`, `hashedPassword` from public to private, getters for these fields were added.
  - Replaced `System.out.println` with `Logger` for logging messages.
  - Replaced `Statement` with `PreparedStatement` to prevent SQL injection attacks.
  - Exception handling was improved by logging the error messages instead of printing stack trace.
  - Close `PreparedStatement` after use to prevent resource leaks.
  - Code readability was improved by removing unnecessary variables and lines.

**Recommendations:** 

- Review if the use of the `Logger` is consistent across all the classes.
- Ensure that the SQL query in the `fetch` method works as expected and retrieves the correct user data.
- The `token` method was modified, ensure that the returned token still meets the requirements.
- The `assertAuth` method was modified, ensure that it still correctly validates the token.
  
**Explanation of Vulnerabilities:** 

- The code was vulnerable to SQL injection attacks because it was using `Statement` and building SQL queries by concatenating strings. This has been addressed by switching to `PreparedStatement` which automatically escapes special characters, preventing SQL injection attacks.
- Resource leak could happen because the `PreparedStatement` was not being closed after use. This has been addressed by closing the statement in the finally block.
- Sensitive data like `id`, `username`, `hashedPassword` were publicly accessible. This has been addressed by changing them to private and providing getters.
- Stack trace was being printed to the console whenever an exception occurred, which could expose sensitive information. This has been addressed by logging the error messages instead.